### PR TITLE
fix(base): re-enable `unicode-bom` rules

### DIFF
--- a/packages/stylelint-config-copilot-base/README.md
+++ b/packages/stylelint-config-copilot-base/README.md
@@ -28,3 +28,14 @@ _Example: Rename [`.stylelintrc.example.js`](.stylelintrc.example.js) to `.style
 - [stylelint-config-copilot-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-scss) - Shareable config based with scss specific rules
 - [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
 - [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order) - Shareable config for order specific rules
+
+## Troubleshooting
+
+- VSCode: `stylelint: Undefined rule unicode-bom`: 
+This is an issue that (might) occur when using `vscode-stylelint (shinnn.stylelint)` or `vscode-stylelint-plus (hex-ci.stylelint-plus)`. Use the official [`stylelint.vscode-stylelint`](https://github.com/stylelint/vscode-stylelint) extension which should fix the problem. If the linter still throws the warning/error, you can overwrite the rule in your config:
+
+```json
+"rules": {
+  "unicode-bom": null
+}
+```

--- a/packages/stylelint-config-copilot-base/index.js
+++ b/packages/stylelint-config-copilot-base/index.js
@@ -23,7 +23,7 @@ module.exports = {
     /* end */
 
     // Require or disallow the Unicode Byte Order Mark.
-    // 'unicode-bom': null,
+    'unicode-bom': null,
 
     'max-empty-lines': 5,
 


### PR DESCRIPTION
- re-enable rule
- add troubleshooting documentation to recommend working vscode-stylelint extension
- fixes unused rule output when runnign find-rules