### PR TITLE
feat(order): add group for `gap` properties

### DIFF
--- a/packages/stylelint-config-copilot-order/index.js
+++ b/packages/stylelint-config-copilot-order/index.js
@@ -63,6 +63,15 @@ module.exports = {
         ],
       },
       {
+        groupName: 'gaps',
+        order: 'flexible',
+        properties: [
+          'gap',
+          'column-gap',
+          'row-gap',
+        ],
+      },      
+      {
         groupName: 'grid',
         order: 'flexible',
         properties: [
@@ -81,7 +90,6 @@ module.exports = {
           'grid-template-areas',
           'grid-template-columns',
           'grid-template-rows',
-          'gap',
         ],
       },
       {
@@ -147,7 +155,6 @@ module.exports = {
           'columns',
           'column-count',
           'column-fill',
-          'column-gap',
           'column-span',
           'column-width',
           'column-rule',


### PR DESCRIPTION
I was wondering how to set the order for `gap`, `row-gap` and `column-gap` for `display: grid`, `display: flexbox` and CSS columns. 

With the current configuration we have to put `gap` for grid layout after the grid properties and for flexbox layout before the flexbox properties:

```css
.grid {
	display: grid;
	grid-template-columns: 1fr 2fr;
	grid-template-rows: 1fr 1fr;
	gap: 10px;
}

.flexbox {
	display: flex;
	gap: 10px;
	flex-wrap: wrap;
	justify-content: space-between;
}
```

I don’t think it’s possible to create multiple rules for the same property for different layout methods. Maybe a new group `gaps` before or after the other layout groups (`grid`, `flexbox-container`, `columns`) would be an option. I choose before, because there are other groups between flexbox related groups and `columns`.

I have also added support for `row-gap`.