### PR TITLE
docs: replace `master` with `main` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stylelint-config-copilot [![CircleCI](https://circleci.com/gh/fuhlig/stylelint-config-copilot/tree/master.svg?style=svg)](https://circleci.com/gh/fuhlig/stylelint-config-copilot/tree/master)  [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
+# stylelint-config-copilot [![CircleCI](https://circleci.com/gh/fuhlig/stylelint-config-copilot/tree/main.svg?style=svg)](https://circleci.com/gh/fuhlig/stylelint-config-copilot/tree/main)  [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 
 
 
@@ -16,7 +16,7 @@ The configs are separated into dedicated packages:
 - [base](/packages/stylelint-config-copilot-base): stylelint's built-in rules
 - [scss](/packages/stylelint-config-copilot-scss): Sass (scss syntax) specific rules
 - [plugins](/packages/stylelint-config-copilot-plugins): rules from various stylelint plugins
-- [order](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order) - order specific rules
+- [order](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-order) - order specific rules
 
 Usage information are in the packages' documentations.
 

--- a/packages/stylelint-config-copilot-base/README.md
+++ b/packages/stylelint-config-copilot-base/README.md
@@ -25,9 +25,9 @@ _Example: Rename [`.stylelintrc.example.js`](.stylelintrc.example.js) to `.style
 
 ## Related
 
-- [stylelint-config-copilot-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-scss) - Shareable config based with scss specific rules
-- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
-- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order) - Shareable config for order specific rules
+- [stylelint-config-copilot-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-scss) - Shareable config based with scss specific rules
+- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
+- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-order) - Shareable config for order specific rules
 
 ## Troubleshooting
 

--- a/packages/stylelint-config-copilot-base/package.json
+++ b/packages/stylelint-config-copilot-base/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-copilot-base",
   "version": "1.0.0-rc.2",
   "description": "Opinionated Stylelint-Configuration",
-  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-base",
+  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-base",
   "main": "index.js",
   "engines": {
     "node": ">=12"

--- a/packages/stylelint-config-copilot-order/README.md
+++ b/packages/stylelint-config-copilot-order/README.md
@@ -29,6 +29,6 @@ _Example: Rename [`.stylelintrc.example.js`](.stylelintrc.example.js) to `.style
 
 ## Related
 
-- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
-- [stylelint-config-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-scss) - Shareable config for Sass (scss) support
-- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
+- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
+- [stylelint-config-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-scss) - Shareable config for Sass (scss) support
+- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins

--- a/packages/stylelint-config-copilot-order/package.json
+++ b/packages/stylelint-config-copilot-order/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-copilot-order",
   "version": "1.0.0-rc.2",
   "description": "Opinionated Stylelint-Configuration for order specific rules with stylelint-order",
-  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order",
+  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-order",
   "main": "index.js",
   "engines": {
     "node": ">=12"

--- a/packages/stylelint-config-copilot-plugins/README.md
+++ b/packages/stylelint-config-copilot-plugins/README.md
@@ -45,6 +45,6 @@ _Example: Rename [`.stylelintrc.example.js`](.stylelintrc.example.js) to `.style
 
 ## Related
 
-- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
-- [stylelint-config-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-scss) - Shareable config for Sass (scss) support
-- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order) - Shareable config for order specific rules
+- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
+- [stylelint-config-scss](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-scss) - Shareable config for Sass (scss) support
+- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-order) - Shareable config for order specific rules

--- a/packages/stylelint-config-copilot-plugins/package.json
+++ b/packages/stylelint-config-copilot-plugins/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-copilot-plugins",
   "version": "1.0.0-rc.2",
   "description": "Opinionated Stylelint-Configuration for stylelint plugins",
-  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-plugins",
+  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-plugins",
   "main": "index.js",
   "engines": {
     "node": ">=12"

--- a/packages/stylelint-config-copilot-scss/README.md
+++ b/packages/stylelint-config-copilot-scss/README.md
@@ -27,6 +27,6 @@ _Example: Rename [`.stylelintrc.example.js`](.stylelintrc.example.js) to `.style
 
 ## Related
 
-- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
-- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
-- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-order) - Shareable config for order specific rules
+- [stylelint-config-copilot-base](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-base) - Shareable config based on built-in rules
+- [stylelint-config-copilot-plugins](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-plugins) - Shareable config for various stylelint plugins
+- [stylelint-config-copilot-order](https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-order) - Shareable config for order specific rules

--- a/packages/stylelint-config-copilot-scss/package.json
+++ b/packages/stylelint-config-copilot-scss/package.json
@@ -2,7 +2,7 @@
   "name": "stylelint-config-copilot-scss",
   "version": "1.0.0-rc.2",
   "description": "Opinionated Stylelint-Configuration for Sass (scss)",
-  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/master/packages/stylelint-config-copilot-scss",
+  "repository": "https://github.com/fuhlig/stylelint-config-copilot/tree/main/packages/stylelint-config-copilot-scss",
   "main": "index.js",
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
#551 