### PR TITLE
feat(rules): disable `length-zero-no-unit` rule

### DIFF
--- a/packages/stylelint-config-copilot-base/index.js
+++ b/packages/stylelint-config-copilot-base/index.js
@@ -76,7 +76,7 @@ module.exports = {
     'no-invalid-position-at-import-rule': null,
 
     // Disallow units for zero lengths.
-    'length-zero-no-unit': true,
+    'length-zero-no-unit': null,
 
     /* ------------------------------------*\
             #COLOR


### PR DESCRIPTION
Zero length values without unit do not work in CSS calculations. Therefore, it often makes sense to allow them.

Example:

```css
.example {
    --foo: 0;
    --bar: 0px;
    margin-top: calc(var(--foo) + 1rem); /* = 0 */
    margin-bottom: calc(var(--bar) + 1rem); /* = 16px */
}
```